### PR TITLE
fix exception when type schema json contains x-psx-mapping attr

### DIFF
--- a/src/Parser/TypeSchema/BCLayer.php
+++ b/src/Parser/TypeSchema/BCLayer.php
@@ -52,6 +52,10 @@ class BCLayer
             $data->type = 'struct';
         }
 
+        if (isset($data->{'x-psx-mapping'})) {
+            $data->{'x-psx-mapping'} = (array) $data->{'x-psx-mapping'};
+        }
+
         if (!isset($data->type)) {
             if (isset($data->additionalProperties) || isset($data->schema)) {
                 $data->type = 'map';

--- a/tests/Generator/resource/source_typeschema.json
+++ b/tests/Generator/resource/source_typeschema.json
@@ -243,6 +243,9 @@
           "description": "Optional describes the format of the string. Supported are the following types: date, date-time and time. A code generator may use a fitting data type to represent such a format, if not supported it should fall back to a string.",
           "type": "string"
         }
+      },
+      "x-psx-mapping": {
+        "format": "format"
       }
     },
     "StructDefinitionType": {


### PR DESCRIPTION
I ran into an edge case using psx/schema to generate PHP DTOs from TypeScript via intermediary TypeSchema json representation.  
On TypeScript side, I have field metadata, identifying source DB field name, that is in underscore case. I was looking for an option to capture this field name mapping in TypeSchema. After a quick look into the repo, I discovered I could make use of custom `x-psx-mapping` TypeSchema JSON attribute (which isn't documented btw).  

This commit fixes PHP parser/generator combo exception when dealing with x-psx-mapping attribute.